### PR TITLE
ci: isolate Dockerfile lint permissions

### DIFF
--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -35,14 +35,11 @@ env:
   DOCKER_BUILD_CHECKS_ANNOTATIONS: false
 
 jobs:
-  build:
-    name: Build ${{ inputs.image_name }}
+  docker_lint:
+    name: Lint ${{ inputs.image_name }} Dockerfile
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
-      attestations: write
-      id-token: write
     steps:
       - name: checkout code
         uses: actions/checkout@v7
@@ -54,6 +51,19 @@ jobs:
         uses: immanuwell/dockerfile-roast@1.5.0
         with:
           files: ${{ inputs.image_name }}/Dockerfile
+
+  build:
+    name: Build ${{ inputs.image_name }}
+    runs-on: ubuntu-latest
+    needs: docker_lint
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v7
 
       - name: Extract app version
         id: get_version

--- a/.github/workflows/reusable-debian-image.yml
+++ b/.github/workflows/reusable-debian-image.yml
@@ -48,14 +48,11 @@ env:
   DOCKER_BUILD_CHECKS_ANNOTATIONS: false
 
 jobs:
-  build:
-    name: Build ${{ inputs.image_name }}
+  docker_lint:
+    name: Lint ${{ inputs.image_name }} Dockerfile
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
-      attestations: write
-      id-token: write
     steps:
       - name: checkout code
         uses: actions/checkout@v7
@@ -67,6 +64,19 @@ jobs:
         uses: immanuwell/dockerfile-roast@1.5.0
         with:
           files: ${{ inputs.image_name }}/Dockerfile
+
+  build:
+    name: Build ${{ inputs.image_name }}
+    runs-on: ubuntu-latest
+    needs: docker_lint
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v7
 
       - name: Docker meta
         id: meta


### PR DESCRIPTION
## Summary
- run Dockerfile linters in read-only jobs
- keep registry publishing and attestations in dependent build jobs

## Validation
- actionlint .github/workflows/*.yml
- git diff --check